### PR TITLE
Register tokens by command instead of as a global set.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,17 +6,17 @@
 ```go
 slack := slacker.New(tokens)
 
-slack.HandleFunc("hello", func(cmd *slacker.Command) error {
+slack.HandleFunc("hello", "foo", func(cmd *slacker.Command) error {
   fmt.Fprint(cmd, "Hello")
   fmt.Fprint(cmd, " World")
   return nil
 })
 
-slack.HandleFunc("boom", func(cmd *slacker.Command) error {
+slack.HandleFunc("boom", "foo", func(cmd *slacker.Command) error {
   return fmt.Errorf("something exploded")
 })
 
-slack.HandleFunc("deploy", func(cmd *slacker.Command) error {
+slack.HandleFunc("deploy", "foo", func(cmd *slacker.Command) error {
   fmt.Fprintf(cmd, "Deploying %q", cmd.Text)
   return nil
 })
@@ -78,23 +78,23 @@ Slacker handles HTTP requests and command dispatching.
 #### func  New
 
 ```go
-func New(tokens []string) *Slacker
+func New() *Slacker
 ```
-New slacker with valid `tokens`.
+New slacker.
 
 #### func (*Slacker) Handle
 
 ```go
-func (s *Slacker) Handle(name string, handler Handler)
+func (s *Slacker) Handle(name, token string, handler Handler)
 ```
-Handle registers `handler` for command `name`.
+Handle registers `handler` for command `name` with `token`.
 
 #### func (*Slacker) HandleFunc
 
 ```go
-func (s *Slacker) HandleFunc(name string, handler func(*Command) (string, error))
+func (s *Slacker) HandleFunc(name, token string, handler func(*Command) (string, error))
 ```
-HandleFunc registers `handler` function for command `name`.
+HandleFunc registers `handler` function for command `name` with `token`.
 
 #### func (*Slacker) ServeHTTP
 
@@ -106,6 +106,6 @@ ServeHTTP handles slash command requests.
 #### func (*Slacker) ValidToken
 
 ```go
-func (s *Slacker) ValidToken(token string) bool
+func (s *Slacker) ValidToken(command, token string) bool
 ```
-ValidToken validates the given `token` against the set provided.
+ValidToken validates the given `token` for the command. Returns `false` if the command is not registered.

--- a/example/main.go
+++ b/example/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/segmentio/go-slacker"
-	"github.com/tj/docopt"
 	"log"
 	"net/http"
+
+	"github.com/segmentio/go-slacker"
+	"github.com/tj/docopt"
 )
 
 var Version = "0.0.1"
@@ -31,22 +32,22 @@ func main() {
 	}
 
 	addr := args["--bind"].(string)
-	tokens := args["--token"].([]string)
+	token := args["--token"].([]string)
 
 	log.Printf("[info] starting slacker %s", Version)
-	slack := slacker.New(tokens)
+	slack := slacker.New()
 
-	slack.HandleFunc("hello", func(cmd *slacker.Command) error {
+	slack.HandleFunc("hello", token, func(cmd *slacker.Command) error {
 		fmt.Fprint(cmd, "Hello")
 		fmt.Fprint(cmd, " World")
 		return nil
 	})
 
-	slack.HandleFunc("boom", func(cmd *slacker.Command) error {
+	slack.HandleFunc("boom", token, func(cmd *slacker.Command) error {
 		return fmt.Errorf("something exploded")
 	})
 
-	slack.HandleFunc("deploy", func(cmd *slacker.Command) error {
+	slack.HandleFunc("deploy", token, func(cmd *slacker.Command) error {
 		fmt.Fprintf(cmd, "Deploying %q", cmd.Text)
 		return nil
 	})

--- a/slacker.go
+++ b/slacker.go
@@ -53,34 +53,43 @@ func (c *Command) String() string {
 
 // Slacker handles HTTP requests and command dispatching.
 type Slacker struct {
-	handlers map[string]Handler
+	handlers map[string]Handler // maps a command to its handler.
+	tokens   map[string]string  // maps a command to its token.
 	sync.Mutex
-	tokens map[string]bool
 }
 
-// New slacker with valid `tokens`.
+// New slacker.
 func New(tokens []string) *Slacker {
 	return &Slacker{
 		handlers: make(map[string]Handler),
-		tokens:   toMap(tokens),
 	}
 }
 
-// ValidToken validates the given `token` against the set provided.
-func (s *Slacker) ValidToken(token string) bool {
+// ValidToken validates the given `token` for the given `command`.
+func (s *Slacker) ValidToken(command, token string) bool {
 	s.Lock()
 	defer s.Unlock()
-	return s.tokens[token]
+
+	// Under normal execution, we would have already validated whether the command
+	// exists or not. But since this an exported function, we must validate that
+	// the command does indeed exist.
+	t, ok := s.tokens[command]
+	if ok {
+		return t == token
+	}
+
+	return false
 }
 
-// Handle registers `handler` for command `name`.
-func (s *Slacker) Handle(name string, handler Handler) {
+// Handle registers `handler` for command `name` with `token`.
+func (s *Slacker) Handle(name, token string, handler Handler) {
 	s.handlers[name] = handler
+	s.tokens[name] = token
 }
 
-// HandleFunc registers `handler` function for command `name`.
-func (s *Slacker) HandleFunc(name string, handler func(*Command) error) {
-	s.Handle(name, HandlerFunc(handler))
+// HandleFunc registers `handler` function for command `name` with `token`.
+func (s *Slacker) HandleFunc(name, token string, handler func(*Command) error) {
+	s.Handle(name, token, HandlerFunc(handler))
 }
 
 // ServeHTTP handles slash command requests.
@@ -109,21 +118,20 @@ func (s *Slacker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ChannelName: r.Form.Get("channel_name"),
 	}
 
-	if !s.ValidToken(cmd.Token) {
-		log.Printf("[error] invalid token %q", cmd.Token)
-		http.Error(w, fmt.Sprintf("Invalid token %q", cmd.Token), 401)
-		return
-	}
-
-	log.Printf("[info] received %s %q from %s in %s", cmd.Name, cmd.Text, cmd.UserName, cmd.ChannelName)
-
 	h, ok := s.handlers[cmd.Name]
-
 	if !ok {
 		log.Printf("[error] invalid command %q", cmd.Name)
 		http.Error(w, "Invalid command", 400)
 		return
 	}
+
+	if !s.ValidToken(cmd.Name, cmd.Token) {
+		log.Printf("[error] invalid token %q for command %q", cmd.Token, cmd.Name)
+		http.Error(w, fmt.Sprintf("Invalid token %q for command %q", cmd.Token, cmd.Name), 401)
+		return
+	}
+
+	log.Printf("[info] received %s %q from %s in %s", cmd.Name, cmd.Text, cmd.UserName, cmd.ChannelName)
 
 	err = h.HandleCommand(cmd)
 	if err != nil {


### PR DESCRIPTION
This way the /foo command only works if the client has the /foo
token. It will fail if the client tries to trigger /foo with a token
for /bar.

Closes #1.
